### PR TITLE
ENG 1363 - Update stripe sdk to latest version ios/android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'com.stripe:stripe-android:16.10.0'
+    implementation 'com.stripe:stripe-android:20.15.1'
 }
 
 def configureReactNativePom(def pom) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-stripe-payments",
   "title": "React Native Stripe Payments",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Lightweight, easy to integrate and use React native library for Stripe payments (using Payment Intents) compliant with SCA (strong customer authentication).",
   "main": "lib/index.tsx",
   "types": "build/index.d.ts",

--- a/react-native-stripe-payments.podspec
+++ b/react-native-stripe-payments.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "Stripe", "~> 21.4.0"
+  s.dependency "Stripe", "~> 23.0.0"
 end


### PR DESCRIPTION
https://linear.app/nomod/issue/ENG-1363/update-react-native-stripe-payments-and-nomod-app-repo-to-use-latest